### PR TITLE
fix: 由于defaultSchema.string被引用,导致所有节点的默认值和备注等引用同一个对象,会一起变化

### DIFF
--- a/src/json-schema-editor.vue
+++ b/src/json-schema-editor.vue
@@ -410,7 +410,7 @@ export default {
       const ranName = 'field_' + uuid()
       const propertiesData = get(this.schemaData, parentPrefix)
       newPropertiesData = Object.assign({}, propertiesData)
-      newPropertiesData[ranName] = defaultSchema.string
+      newPropertiesData[ranName] = cloneDeep(defaultSchema.string)
       const cloneSchema = cloneDeep(this.schemaData)
       set(cloneSchema, parentPrefix, newPropertiesData)
 


### PR DESCRIPTION
由于新增节点时，都是用的defaultSchema.string这个对象，导致所有的节点引用的同一个对象，新增节点就是和上一个一样，而且改变其中一个节点的默认值或者备注，另一个也会同步更新，使得无法修改，应该要深拷贝一下，当然直接{...defaultSchema.string}也可以